### PR TITLE
Fix 16F1459 erase bug in uploader8.py

### DIFF
--- a/pinguino/qtgui/pinguino_core/uploader/uploader8.py
+++ b/pinguino/qtgui/pinguino_core/uploader/uploader8.py
@@ -538,8 +538,8 @@ class uploader8(baseUploader):
         # erase memory from board.memstart to max_address
         # --------------------------------------------------------------
 
-        numBlocksMax = (board.memend - board.memstart) / eraseBlockSize
-        numBlocks    = (max_address  - board.memstart) / eraseBlockSize
+        numBlocksMax = (MEMEND      - MEMSTART) / eraseBlockSize
+        numBlocks    = (max_address - MEMSTART) / eraseBlockSize
         #self.add_report("numBlocks    : %d" % numBlocks)
         #self.add_report("numBlocksMax : %d" % numBlocksMax)
 


### PR DESCRIPTION
On the 16F1459, program memory is addressed in words rather than bytes.
The uploader code works in bytes, so MEMEND and MEMSTART are defined as
the byte equivalents of board.memstart and board.memend. However, these
new variables are not used when calculating the number of blocks to
erase. The available memory in words is instead divided by the erase
block size in bytes. This error means that blocks beyond address 0x1280
are never erased, causing problems when a program is written to these
blocks.

This change correctly uses MEMEND and MEMSTART to calculate the number
of blocks to erase. This fixes the bug on 16F1459, but I can't be sure
this does not have unintended effects on other 8-bit MCUs as I don't
have any other Pinguino's to test on.